### PR TITLE
feat: update helm chart to v7 to use workload identity

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: microservice-chart
   repository: https://pagopa.github.io/aks-microservice-chart-blueprint
-  version: 6.0.0
-digest: sha256:c605360615d8b4b00139d3e1ce3366df8fd705d2b5ea634ddfac0287f8b16109
-generated: "2024-09-06T16:43:15.944614+02:00"
+  version: 7.3.1
+digest: sha256:f7a6ce88959f9eddc5929c3a4506fce505fd2f0bc81bedd11f1d79b3c5ac7a17
+generated: "2025-02-21T11:52:35.993187+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.0.1
 appVersion: 0.0.1
 dependencies:
   - name: microservice-chart
-    version: 6.0.0
+    version: 7.3.1
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,6 +2,20 @@ microservice-chart:
   namespace: "pay-wallet"
   nameOverride: ""
   fullnameOverride: "pagopa-pay-wallet-helpdesk-service"
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopaditncoreacr.azurecr.io/pagopapaymentwallethelpdeskservice
+      tag: "latest"
+    envConfig: { }
+    envSecret: { }
   image:
     repository: pagopaditncoreacr.azurecr.io/pagopapaymentwallethelpdeskservice
     tag: "0.0.1"
@@ -35,7 +49,7 @@ microservice-chart:
   serviceAccount:
     create: false
     annotations: { }
-    name: ""
+    name: "pay-wallet-workload-identity"
   podAnnotations: { }
   podSecurityContext:
     seccompProfile:
@@ -80,10 +94,6 @@ microservice-chart:
     name: "pagopa-d-pay-wallet-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
   nodeSelector: { }
-  canaryDelivery:
-    deployment:
-      image:
-        tag: ""
   tolerations:
     - effect: "NoSchedule"
       key: "paymentWalletOnly"
@@ -104,6 +114,8 @@ microservice-chart:
           podAffinityTerm:
             labelSelector:
               matchLabels:
-                aadpodidbinding: pay-wallet-pod-identity
+                app.kubernetes.io/instance: pagopapaymentwallethelpdeskservice
             namespaces: [ "pay-wallet" ]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: 8cad3639-cc88-4bff-85fe-5b1ddb2d449e


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.8.0 to 7.3.1
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modification are needed in order to make payment wallet use workload identities instead of deprecated pod identity
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Deploy in dev env
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
